### PR TITLE
Fix code for v4 prometheus URLs and change env var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The purpose of this script is to automate the creation of dashboards and their r
 
     ```bash
     Secret=$(oc get secret customer-secret -o "jsonpath={.data['customer_clusters\.yaml']}" | base64 --decode) && oc new-app python:3.6~https://github.com/UKCloud/openshift-automation-grafana.git \
-        -e OPENSHIFT_SECRET=$Secret \
-        -e GRAFANA_API_KEY="API key here." \
-        -e GRAFANA_HOST="https://grafanahost.com"
+        -e DASHBOARD_SOURCES=$Secret \
+        -e GRAFANA_API_TOKEN="API token here." \
+        -e GRAFANA_URL="https://grafanaurl.ukcloud.uk"
     ```

--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ def main():
             name = "{}-{}".format(customer, clustername)
             datasource_info.append([name, clustername])
 
-            logging.debug("Creating data source for customer: {} cluster: {}".format(customer, clustername))
+            logging.debug(f"Creating data source for customer: {customer} cluster: {clustername}")
             datasource = {
                 "name": name,
                 "type": "prometheus",
@@ -55,18 +55,21 @@ def main():
             }
             try:
                 resp = grafana_request(session, sub_endpoint="/api/datasources", method="POST", json=datasource)
-                logging.debug(f"JSON response for data source creation: data source: {cluster["ClusterDataSourceUrl"]} "
-                              "JSON payload: {resp}")
+                logging.debug(f"JSON response for data source creation: data source: {cluster['ClusterDataSourceUrl']}\n"
+                              f"JSON payload: {resp}")
                 # Sleep for a second to avoid Grafana raising 409 conflict error.
                 sleep(1)
             except HTTPError as err:
-                logging.debug(f"Failed to create Grafana data source: {err}\nJSON payload: {datasource}")
+                logging.debug(f"Failed to create Grafana data source: {err}\n"
+                              f"JSON payload: {datasource}")
         dashboard = create_template(datasource_info, customer)
         try:
             resp = grafana_request(session, sub_endpoint="/api/dashboards/db", method="POST", data=dashboard)
-            logging.debug(f"JSON response for dashboard creation: dashboard: {customer}\nJSON payload: {resp}")
+            logging.debug(f"JSON response for dashboard creation: dashboard: {customer}\n"
+                          f"JSON payload: {resp}")
         except HTTPError as err:
-            logging.debug(f"Failed to create Grafana dashboard: {err}\nJSON payload: {dashboard}")
+            logging.debug(f"Failed to create Grafana dashboard: {err}\n"
+                          f"JSON payload: {dashboard}")
     session.close()
 
 


### PR DESCRIPTION
Changed the way the url is split, so it uses the last 5 dot-separated parts of the url passed, which is the current format for our domain suffixes, which are joined again with '.' 
Removed comments which described the next line of code. 
Changed environment variable names to more closely match what they contain.
Updated string formatting to use python3 f-strings.
Bumped major version as the environment variable rename is a breaking change. 
